### PR TITLE
Support for fractional seconds as per the Aurora docs during bind

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -140,6 +140,14 @@ class User(Base):
 
 
 class TestAuroraDataAPI(unittest.TestCase):
+    dialect = "postgresql+auroradataapi://"
+
+    @classmethod
+    def setUpClass(cls):
+        register_dialects()
+        cls.db_name = os.environ.get("AURORA_DB_NAME", __name__)
+        cls.engine = create_engine(cls.dialect + ':@/' + cls.db_name)
+
     @classmethod
     def tearDownClass(cls):
         pass
@@ -174,7 +182,7 @@ class TestAuroraDataAPIPostgresDialect(TestAuroraDataAPI):
         blob = b"0123456789ABCDEF" * 1024
         friends = ["Scarlett O'Hara", 'Ada "Hacker" Lovelace']
         Base.metadata.create_all(self.engine)
-        added = datetime.datetime.now()
+        added = datetime.datetime.now().replace(microsecond=123456)
         ed_user = User(name='ed', fullname='Ed Jones', nickname='edsnickname', doc=doc, doc2=doc, uuid=str(uuid),
                        flag=True, birthday=datetime.datetime.fromtimestamp(0), added=added, floated=1.2, nybbled=blob,
                        friends=friends, num_friends=500, num_laptops=9000, first_date=added, note='note',
@@ -195,7 +203,7 @@ class TestAuroraDataAPIPostgresDialect(TestAuroraDataAPI):
         self.assertEqual(u.flag, True)
         self.assertEqual(u.nonesuch, None)
         self.assertEqual(u.birthday, datetime.date.fromtimestamp(0))
-        self.assertEqual(u.added, added.replace(microsecond=0))
+        self.assertEqual(u.added, added.replace(microsecond=123000))
         self.assertEqual(u.floated, 1.2)
         self.assertEqual(u.nybbled, blob)
         self.assertEqual(u.friends, friends)
@@ -256,7 +264,7 @@ class TestAuroraDataAPIMySQLDialect(TestAuroraDataAPI):
         self.assertEqual(u.nickname, "edsnickname")
         self.assertEqual(u.birthday, birthday)
         self.assertEqual(u.eats_breakfast_at, eats_breakfast_at.replace(microsecond=0))
-        self.assertEqual(u.married_at, married_at.replace(microsecond=0))
+        self.assertEqual(u.married_at, married_at.replace(microsecond=200000))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently when `datetime.datetime` or `datetime.time` are bound, the fractional component of the value is discarded, leading to precision at but not below a second. The data API supports a fractional component with a precision of three digits as per the docs, so this change passes a fractional component through formatted appropriately.